### PR TITLE
Move feeder motor to Hopper

### DIFF
--- a/src/org/usfirst/frc/team4131/robot/Robot.java
+++ b/src/org/usfirst/frc/team4131/robot/Robot.java
@@ -45,7 +45,6 @@ public class Robot extends IterativeRobot{
 	@Override
 	public void teleopPeriodic(){
 		Scheduler.getInstance().run();
-		
 	}
 	@Override
 	public void testInit(){

--- a/src/org/usfirst/frc/team4131/robot/subsystems/Hopper.java
+++ b/src/org/usfirst/frc/team4131/robot/subsystems/Hopper.java
@@ -10,6 +10,7 @@ import edu.wpi.first.wpilibj.command.Subsystem;
  * ========== Test Procedure ==========
  * Ran on Robot in a Box
  * We will call {@link #agitateFuel()} and {@link #feedShooter()} in teleopPeriodic, and expect both motors to run when teleop is enabled.
+ * Tests passed
  * ====================================
  * @author Matthew, Ian
  * @since 2/18/2017

--- a/src/org/usfirst/frc/team4131/robot/subsystems/Hopper.java
+++ b/src/org/usfirst/frc/team4131/robot/subsystems/Hopper.java
@@ -9,24 +9,28 @@ import edu.wpi.first.wpilibj.command.Subsystem;
 /**
  * ========== Test Procedure ==========
  * Ran on Robot in a Box
- * We will enable teleop, and expect motor to turn at maximum speed.
- * Test passed
+ * We will call {@link #agitateFuel()} and {@link #feedShooter()} in teleopPeriodic, and expect both motors to run when teleop is enabled.
  * ====================================
- * @author Matthew
- * @since 1/20/2017
+ * @author Matthew, Ian
+ * @since 2/18/2017
  */
-public class Hopper extends Subsystem {
-	private CANTalon hopperMotor;
-	public Hopper(){
-		hopperMotor = new CANTalon(RobotMap.HOPPER_MOTOR);
+public class Hopper extends Subsystem{
+	private CANTalon hopperMotor = new CANTalon(RobotMap.HOPPER_MOTOR);
+	private CANTalon feederMotor = new CANTalon(RobotMap.FEEDER_MOTOR);
+	public Hopper(){}
+	protected void initDefaultCommand(){
+		
 	}
-	protected void initDefaultCommand() {
-	
-	}
-	public void run() {
+	public void agitateFuel(){
 		hopperMotor.set(1);
 	}
-	public void stop() {
+	public void settleFuel(){
 		hopperMotor.set(0);
 	}
+	public void feedShooter(){
+		feederMotor.set(1);
 	}
+	public void stopFeeder(){
+		feederMotor.set(0);
+	}
+}

--- a/src/org/usfirst/frc/team4131/robot/subsystems/Shooter.java
+++ b/src/org/usfirst/frc/team4131/robot/subsystems/Shooter.java
@@ -10,6 +10,7 @@ import edu.wpi.first.wpilibj.command.Subsystem;
  * ========== Test Procedure ==========
  * Ran on Robot in a Box
  * We will call {@link #runFlywheel()} in teleopPeriodic, and expect the motor to turn at maximum speed when teleop is enabled.
+ * Tests passed
  * ====================================
  * @author Matthew
  * @since 1/28/2017

--- a/src/org/usfirst/frc/team4131/robot/subsystems/Shooter.java
+++ b/src/org/usfirst/frc/team4131/robot/subsystems/Shooter.java
@@ -9,30 +9,20 @@ import edu.wpi.first.wpilibj.command.Subsystem;
 /**
  * ========== Test Procedure ==========
  * Ran on Robot in a Box
- * We will enable teleop, and expect both motors to turn at maximum speed in the same direction.
- * Test passed
+ * We will call {@link #runFlywheel()} in teleopPeriodic, and expect the motor to turn at maximum speed when teleop is enabled.
  * ====================================
  * @author Matthew
  * @since 1/28/2017
  */
 
-public class Shooter extends Subsystem {
-	private CANTalon feederMotor = new CANTalon(RobotMap.FEEDER_MOTOR);
+public class Shooter extends Subsystem{
 	private CANTalon flywheelMotor = new CANTalon(RobotMap.FLYWHEEL_MOTOR);
-	protected void initDefaultCommand() {
-	}
-	public Shooter(){
-	}
-	public void runFeeder() {
-		feederMotor.set(1);
-	}
-	public void stopFeeder() {
-		feederMotor.set(0);
-	}
-	public void runFlywheel() {
+	protected void initDefaultCommand(){}
+	public Shooter(){}
+	public void runFlywheel(){
 		flywheelMotor.set(1);
 	}
-	public void stopFlywheel() {
+	public void stopFlywheel(){
 		flywheelMotor.set(0);
 	}
 }


### PR DESCRIPTION
Having the feeder motor in the shooter subsystem means shooting would require the shooter, and interrupt the ChargeShooter command. Because shooting already requires the hopper to agitate the fuel, it makes sense to put the feeder there.