### PR TITLE
CompBot changes

### DIFF
--- a/src/org/usfirst/frc/team4131/robot/OI.java
+++ b/src/org/usfirst/frc/team4131/robot/OI.java
@@ -4,6 +4,7 @@ import org.usfirst.frc.team4131.robot.commands.*;
 
 import edu.wpi.first.wpilibj.Joystick;
 import edu.wpi.first.wpilibj.buttons.JoystickButton;
+
 /**
  * This class is the glue that binds the controls on the physical operator
  * interface to the commands and command groups that allow control of the robot.
@@ -30,17 +31,17 @@ public class OI{
 	private JoystickButton slowClimb;
 	private JoystickButton killShooter;
 	private JoystickButton shift;
-	public OI() {
+	public OI(){
 		leftStick = new Joystick(RobotMap.LEFT_JOYSTICK);
 		rightStick = new Joystick(RobotMap.RIGHT_JOYSTICK);
 		collect = new JoystickButton(leftStick, 4);
-		spitOut = new JoystickButton(rightStick , 3);
-		chargeShooter = new JoystickButton(leftStick , 1);
-		shoot = new JoystickButton(rightStick , 1);
-		climb = new JoystickButton(leftStick , 7);
-		slowClimb = new JoystickButton(leftStick , 8);
-		killShooter = new JoystickButton(rightStick , 2);
-		shift = new JoystickButton(rightStick , 6);
+		spitOut = new JoystickButton(rightStick, 3);
+		chargeShooter = new JoystickButton(leftStick, 1);
+		shoot = new JoystickButton(rightStick, 1);
+		climb = new JoystickButton(leftStick, 7);
+		slowClimb = new JoystickButton(leftStick, 8);
+		killShooter = new JoystickButton(rightStick, 2);
+		shift = new JoystickButton(rightStick, 6);
 		
 		ChargeShooter chargeShooterCommand = new ChargeShooter();
 		
@@ -52,14 +53,16 @@ public class OI{
 		slowClimb.whileHeld(new EngageClimber());
 		killShooter.cancelWhenPressed(chargeShooterCommand);
 	}
-	public double getLeftSpeed() {
-		return leftStick.getRawAxis(1);
+	public double getLeftSpeed(){
+		return constrain(leftStick.getRawAxis(1));
 	}
-	public double getRightSpeed() {
-		return rightStick.getRawAxis(1);
+	public double getRightSpeed(){
+		return constrain(rightStick.getRawAxis(1));
 	}
-	public boolean shiftDown() {
+	public boolean shiftDown(){
 		return shift.get();
 	}
+	private double constrain(double value){
+		return Math.max(-1, Math.min(1, value));
+	}
 }
-

--- a/src/org/usfirst/frc/team4131/robot/Robot.java
+++ b/src/org/usfirst/frc/team4131/robot/Robot.java
@@ -5,6 +5,7 @@ import org.usfirst.frc.team4131.robot.subsystems.*;
 import edu.wpi.first.wpilibj.Compressor;
 import edu.wpi.first.wpilibj.IterativeRobot;
 import edu.wpi.first.wpilibj.command.Scheduler;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
 /**
  * The VM is configured to automatically run this class, and to call the
@@ -28,15 +29,17 @@ public class Robot extends IterativeRobot{
 	@Override
 	public void robotInit(){
 		drive.resetGyro();
+		drive.resetDistance();
 		compressor.setClosedLoopControl(true);
 	}
 	@Override
 	public void autonomousInit(){
-		
+		drive.resetDistance();
 	}
 	@Override
 	public void autonomousPeriodic(){
 		Scheduler.getInstance().run();
+		dashboard();
 	}
 	@Override
 	public void teleopInit(){
@@ -45,6 +48,7 @@ public class Robot extends IterativeRobot{
 	@Override
 	public void teleopPeriodic(){
 		Scheduler.getInstance().run();
+		dashboard();
 	}
 	@Override
 	public void testInit(){
@@ -53,6 +57,7 @@ public class Robot extends IterativeRobot{
 	@Override
 	public void testPeriodic(){
 		Scheduler.getInstance().run();
+		dashboard();
 	}
 	@Override
 	public void disabledInit(){
@@ -60,6 +65,10 @@ public class Robot extends IterativeRobot{
 	}
 	@Override
 	public void disabledPeriodic(){
-		Scheduler.getInstance().run();
+		dashboard();
+	}
+	private void dashboard(){
+		SmartDashboard.putNumber("Angle", drive.getAngle());
+		SmartDashboard.putNumber("Encoder", drive.getDistance());
 	}
 }

--- a/src/org/usfirst/frc/team4131/robot/RobotMap.java
+++ b/src/org/usfirst/frc/team4131/robot/RobotMap.java
@@ -26,13 +26,12 @@ public class RobotMap {
 	public static final int LEFT_SHIFTER2 = 1;
 	public static final int RIGHT_SHIFTER1 = 2;
 	public static final int RIGHT_SHIFTER2 = 3;
-	public static final int ENCODER_LEFT1 = 0;
-	public static final int ENCODER_LEFT2 = 1;
-	public static final int ENCODER_RIGHT1 = 2;
-	public static final int ENCODER_RIGHT2 = 3;
 	
 	//Constants
-	public static final int DRIVE_INCHES_PER_PULSE = 1;
+	public static final int DRIVE_ENCODER_TICKS = 20;
+	public static final double HIGH_GEAR_RATIO = 0.224, DRIVE_WHEEL_RADIUS = 2;
+	public static final double DRIVE_WHEEL_CIRCUMFERENCE = 2 * Math.PI * DRIVE_WHEEL_RADIUS;
+	public static final double DRIVE_CONVERSION_FACTOR = HIGH_GEAR_RATIO * DRIVE_WHEEL_CIRCUMFERENCE / 80;//The 80 is arbitrary but it works
 	public static final double DRIVE_RAMP_RATE = 12 / 1.5;//Volts per second; full power (12V) divided by time from zero to full
 	public static final boolean DRIVE_LEFT_INVERTED = true, DRIVE_RIGHT_INVERTED = false;
 }

--- a/src/org/usfirst/frc/team4131/robot/RobotMap.java
+++ b/src/org/usfirst/frc/team4131/robot/RobotMap.java
@@ -7,18 +7,19 @@ package org.usfirst.frc.team4131.robot;
  * floating around.
  */
 public class RobotMap {
-	public static final int PCM_ID = 20;
+	public static final int PCM_ID = 62;
 	//Input devices
 	public static final int LEFT_JOYSTICK = 0;
 	public static final int RIGHT_JOYSTICK = 1;
+	
 	//Motors
-	public static final int DRIVE_LEFT = 1;
-	public static final int DRIVE_RIGHT = 2;
+	public static final int DRIVE_LEFT[] = {4, 5, 6};
+	public static final int DRIVE_RIGHT[] = {1, 2, 3};
 	public static final int FLYWHEEL_MOTOR = 7;
-	public static final int FEEDER_MOTOR = 8;
-	public static final int HOPPER_MOTOR = 9;
-	public static final int COLLECTOR_MOTOR = 10;
-	public static final int CLIMBER_MOTOR = 12;
+	public static final int FEEDER_MOTOR = 9;
+	public static final int HOPPER_MOTOR = 10;
+	public static final int COLLECTOR_MOTOR = 11;
+	public static final int CLIMBER_MOTOR = 8;
 	
 	//Digital IO
 	public static final int LEFT_SHIFTER1 = 0;
@@ -32,4 +33,6 @@ public class RobotMap {
 	
 	//Constants
 	public static final int DRIVE_INCHES_PER_PULSE = 1;
+	public static final double DRIVE_RAMP_RATE = 12 / 1.5;//Volts per second; full power (12V) divided by time from zero to full
+	public static final boolean DRIVE_LEFT_INVERTED = false, DRIVE_RIGHT_INVERTED = true;
 }

--- a/src/org/usfirst/frc/team4131/robot/RobotMap.java
+++ b/src/org/usfirst/frc/team4131/robot/RobotMap.java
@@ -34,5 +34,5 @@ public class RobotMap {
 	//Constants
 	public static final int DRIVE_INCHES_PER_PULSE = 1;
 	public static final double DRIVE_RAMP_RATE = 12 / 1.5;//Volts per second; full power (12V) divided by time from zero to full
-	public static final boolean DRIVE_LEFT_INVERTED = false, DRIVE_RIGHT_INVERTED = true;
+	public static final boolean DRIVE_LEFT_INVERTED = true, DRIVE_RIGHT_INVERTED = false;
 }

--- a/src/org/usfirst/frc/team4131/robot/commands/EngageClimber.java
+++ b/src/org/usfirst/frc/team4131/robot/commands/EngageClimber.java
@@ -1,10 +1,9 @@
 package org.usfirst.frc.team4131.robot.commands;
 
 import org.usfirst.frc.team4131.robot.Robot;
-import org.usfirst.frc.team4131.robot.RobotMap;
-
 
 import edu.wpi.first.wpilibj.command.Command;
+
 /**
  * ========== Test Procedure ==========
  * Ran on Robot in a Box

--- a/src/org/usfirst/frc/team4131/robot/subsystems/Climber.java
+++ b/src/org/usfirst/frc/team4131/robot/subsystems/Climber.java
@@ -8,9 +8,9 @@ import edu.wpi.first.wpilibj.command.Subsystem;
 
 /**
  * ========== Test Procedure ==========
- * Run on Robot in a Box
- * We will call {@link #engage()} in teleop, and expect the motor to spin at half speed.
- * We will call {@link #climb()} in teleop, and expect the motor to spin at full speed in the same direction as {{@link #engage()}.
+ * Run on Competition Bot
+ * We will call {@link #engage()} with the climber directly under the rope, and expect the climber to engage the rope and begin to climb.
+ * We will call {@link #climb()} in teleop, and expect the robot to climb the rope.
  * Tests passed
  * ====================================
  * @author Ian

--- a/src/org/usfirst/frc/team4131/robot/subsystems/Collector.java
+++ b/src/org/usfirst/frc/team4131/robot/subsystems/Collector.java
@@ -8,11 +8,11 @@ import edu.wpi.first.wpilibj.command.Subsystem;
 
 /**
  * ========== Test Procedure ==========
- * Run on Robot in a Box
- * We will call {@link #collect()} in teleop, and expect the motor to spin at full speed.
+ * Run on Competition Bot
+ * We will call {@link #collect()} in teleop, and expect the collector to intake fuel on contact.
+ * We will call {@link #eject()} in teleop, and expect the collector to eject all fuel within it.
  * Tests passed
  * ====================================
- * 
  * @author Patrick
  * @since 1/28/2017
  * 

--- a/src/org/usfirst/frc/team4131/robot/subsystems/DriveBase.java
+++ b/src/org/usfirst/frc/team4131/robot/subsystems/DriveBase.java
@@ -16,11 +16,11 @@ import edu.wpi.first.wpilibj.command.Subsystem;
 
 /**
  * ========== Test Procedure ==========
- * Ran on Robot in a Box
+ * Run on Competition Bot
  * We will call {@link #move(double, double)} in teleopPeriodic and expect both motors to move. The same number to both should make them rotate in opposite directions.
  * We will report {@link #getAngle()} in teleopPeriodic and expect it to show the robot's angle of rotation about the axis perpendicular to the floor.
- * We will report {@link #getDistance()} in teleopPeriodic while moving the drive motors and expect the value to change proportional to the motor value.
- * We will call {@link #shiftUp()} and {@link #shiftDown()} and expect them to set the solenoids to forward or reverse.
+ * We will report {@link #getDistance()} in teleopPeriodic and expect it to return the distance traveled since startup.
+ * We will call {@link #shiftUp()} and {@link #shiftDown()} and expect the robot to shift to high and low gear. 
  * Tests passed
  * ====================================
  * @author Calvin, Ian

--- a/src/org/usfirst/frc/team4131/robot/subsystems/DriveBase.java
+++ b/src/org/usfirst/frc/team4131/robot/subsystems/DriveBase.java
@@ -4,6 +4,7 @@ import org.usfirst.frc.team4131.robot.RobotMap;
 import org.usfirst.frc.team4131.robot.commands.Move;
 
 import com.ctre.CANTalon;
+import com.ctre.CANTalon.TalonControlMode;
 import com.kauailabs.navx.frc.AHRS;
 
 import edu.wpi.first.wpilibj.DoubleSolenoid;
@@ -30,15 +31,41 @@ public class DriveBase extends Subsystem {
 	private Encoder leftEncoder, rightEncoder;
 	private AHRS imu;
 	public DriveBase(){
-		leftMotor = new CANTalon(RobotMap.DRIVE_LEFT);
-		rightMotor = new CANTalon(RobotMap.DRIVE_RIGHT);
+		//Create left motor
+		leftMotor = new CANTalon(RobotMap.DRIVE_LEFT[0]);
+		leftMotor.setInverted(RobotMap.DRIVE_LEFT_INVERTED);
+		leftMotor.reverseOutput(RobotMap.DRIVE_LEFT_INVERTED);
+		leftMotor.setVoltageRampRate(RobotMap.DRIVE_RAMP_RATE);
+		
+		//Create right motor
+		rightMotor = new CANTalon(RobotMap.DRIVE_RIGHT[0]);
+		rightMotor.setInverted(RobotMap.DRIVE_RIGHT_INVERTED);
+		rightMotor.reverseOutput(RobotMap.DRIVE_RIGHT_INVERTED);
+		rightMotor.setVoltageRampRate(RobotMap.DRIVE_RAMP_RATE);
+		
+		//Create other motors (as followers)
+		for(int i=1; i<3; ++i){
+			CANTalon left = new CANTalon(RobotMap.DRIVE_LEFT[i]);
+			left.changeControlMode(TalonControlMode.Follower);
+			left.set(RobotMap.DRIVE_LEFT[0]);
+			
+			CANTalon right = new CANTalon(RobotMap.DRIVE_RIGHT[i]);
+			right.changeControlMode(TalonControlMode.Follower);
+			right.set(RobotMap.DRIVE_RIGHT[0]);
+		}
+		//Create shifters
 		leftShifter = new DoubleSolenoid(RobotMap.PCM_ID, RobotMap.LEFT_SHIFTER1, RobotMap.LEFT_SHIFTER2);
 		rightShifter = new DoubleSolenoid(RobotMap.PCM_ID, RobotMap.RIGHT_SHIFTER1, RobotMap.RIGHT_SHIFTER2);
 		
+		//Create left encoder
 		leftEncoder = new Encoder(RobotMap.ENCODER_LEFT1, RobotMap.ENCODER_LEFT2);
-		rightEncoder = new Encoder(RobotMap.ENCODER_RIGHT1, RobotMap.ENCODER_RIGHT2);
 		leftEncoder.setDistancePerPulse(RobotMap.DRIVE_INCHES_PER_PULSE);
+		leftEncoder.setReverseDirection(RobotMap.DRIVE_LEFT_INVERTED);
+		
+		//Create right encoder
+		rightEncoder = new Encoder(RobotMap.ENCODER_RIGHT1, RobotMap.ENCODER_RIGHT2);
 		rightEncoder.setDistancePerPulse(RobotMap.DRIVE_INCHES_PER_PULSE);
+		
 		imu = new AHRS(SPI.Port.kMXP);
 	}
 	

--- a/src/org/usfirst/frc/team4131/robot/subsystems/Shooter.java
+++ b/src/org/usfirst/frc/team4131/robot/subsystems/Shooter.java
@@ -21,7 +21,7 @@ public class Shooter extends Subsystem{
 	protected void initDefaultCommand(){}
 	public Shooter(){}
 	public void runFlywheel(){
-		flywheelMotor.set(1);
+		flywheelMotor.set(-1);
 	}
 	public void stopFlywheel(){
 		flywheelMotor.set(0);


### PR DESCRIPTION
- Update IDs to match competition robot
- Increase to six drive motors, two masters and four followers
- Convert encoders to SRX-connected rather than directly to DIO
- Reverse shooter direction
- Apply ramping to drive motors
- Prevent "overdriving" (at full throttle on the joystick (which exceeds 1.0 according to the driver station), the drive suddenly increases speed) by constraining joystick OI values to the interval [-1.0, 1.0]